### PR TITLE
continue committing after binary content exception

### DIFF
--- a/src/main/java/com/norconex/committer/googlecloudsearch/GoogleCloudSearchCommitter.java
+++ b/src/main/java/com/norconex/committer/googlecloudsearch/GoogleCloudSearchCommitter.java
@@ -236,8 +236,12 @@ public class GoogleCloudSearchCommitter extends AbstractMappedCommitter {
           throw new CommitterException(
               "Content type field ('" + FIELD_CONTENT_TYPE + "') is missing!");
         }
-        AbstractInputStreamContent contentStream = getInputStreamContent(add, contentType);
-        addItem(url, contentType, contentStream, add.getMetadata(), stopWatch);
+        try {
+          AbstractInputStreamContent contentStream = getInputStreamContent(add, contentType);
+          addItem(url, contentType, contentStream, add.getMetadata(), stopWatch);
+        } catch (CommitterException e) {
+          LOG.warn("Exception caught while indexing: " + url, e);
+        }
       } else if (op instanceof IDeleteOperation) {
         String url = ((IDeleteOperation) op).getReference();
         deleteItem(url, stopWatch);


### PR DESCRIPTION
The Google Cloud Search Norconex Committer (latest version v1-0-0.4) does not continue the committing process if one of the documents doesn't contain binary content.

This fix allows the committer to continue at with the documents with valid binary content.